### PR TITLE
Install Poetry in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+      - name: "Install poetry"
+        run: python -m pip install poetry==1.8.2
       - name: Test
         run: |
-          python3 -m pytest
+          poetry run pytest -vv


### PR DESCRIPTION
The GitHub Action does not use `poetry` to run the tests. The build fails because `pytest` is not found.

This PR installs poetry in the virtual machines. It should run on Linux, Windows, and Mac OS X.

The script uses `poetry` to run `pytest`, and it adds the `-vv` flag to make PyTest more verbose.